### PR TITLE
Исправление установки на Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='steem-piston',
                         "python-frontmatter==0.2.1",
                         "prettytable==0.7.2",
                         "colorama==0.3.6",
-                        "scrypt==0.7.1"
+                        "scrypt==0.8.0"
                         ],
       setup_requires=['pytest-runner'],
       tests_require=['pytest'],


### PR DESCRIPTION
Пакет scrypt версии 0.7.1, указанный в зависимостях, не собирается под Windows (по крайней мере, у меня на Win8.1x64 не установилось).
Эта ошибка была исправлена его разработчиками в версии 0.8.0.